### PR TITLE
Add failure status to angular login/register

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -17,6 +17,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": [
+              "axios"
+            ],
             "outputPath": "dist/angular",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -123,6 +126,7 @@
           }
         }
       }
-    }},
+    }
+  },
   "defaultProject": "angular"
 }

--- a/angular/e2e/protractor.conf.js
+++ b/angular/e2e/protractor.conf.js
@@ -16,7 +16,10 @@ exports.config = {
     './src/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    browserName: 'chrome'
+    browserName: 'chrome',
+    loggingPrefs: {
+      browser: 'SEVERE'
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/angular/e2e/src/app.po.ts
+++ b/angular/e2e/src/app.po.ts
@@ -6,6 +6,8 @@ export class AppPage {
     register: element(by.linkText('REGISTER')),
   };
 
+  error = element(by.css('.error'));
+
   login = {
     name: element(by.css('input[type=text]')),
     password: element(by.css('input[type=password]')),

--- a/angular/e2e/src/login.e2e-spec.ts
+++ b/angular/e2e/src/login.e2e-spec.ts
@@ -25,14 +25,29 @@ describe('Login', () => {
     expect(await page.currentUrl()).not.toContain('login');
   });
 
+  it('errors if invalid credentials', async () => {
+    await page.navigateTo();
+    await page.login.name.sendKeys('Joe');
+    await page.login.password.sendKeys('password');
+    expect(await page.error.isPresent()).toBe(false);
+    await page.login.submit.click();
+
+    expect(await page.currentUrl()).toContain('login');
+    expect(await page.error.isPresent()).toBe(true);
+  });
+
   afterEach(async (done) => {
     // Assert that there are no errors emitted from the browser
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(
-      jasmine.objectContaining({
-        level: logging.Level.SEVERE,
-      } as logging.Entry)
-    );
+    expect(
+      logs.some(
+        (l) =>
+          l.level === logging.Level.SEVERE &&
+          !l.message.includes(
+            'http://localhost:4000/api/login - Failed to load resource'
+          )
+      )
+    ).toBe(false);
     await checkinSandbox(sandboxId);
     await browser.executeScript('window.localStorage.clear();');
 

--- a/angular/e2e/src/register.e2e-spec.ts
+++ b/angular/e2e/src/register.e2e-spec.ts
@@ -25,14 +25,30 @@ describe('Register', () => {
     expect(await page.currentUrl()).not.toContain('register');
   });
 
+  it('errors if invalid data', async () => {
+    await page.navigateTo();
+    await page.navigation.register.click();
+    expect(await page.currentUrl()).toContain('register');
+
+    expect(await page.error.isPresent()).toBe(false);
+    await page.register.submit.click();
+
+    expect(await page.currentUrl()).toContain('register');
+    expect(await page.error.isPresent()).toBe(true);
+  });
+
   afterEach(async (done) => {
     // Assert that there are no errors emitted from the browser
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(
-      jasmine.objectContaining({
-        level: logging.Level.SEVERE,
-      } as logging.Entry)
-    );
+    expect(
+      logs.some(
+        (l) =>
+          l.level === logging.Level.SEVERE &&
+          !l.message.includes(
+            'http://localhost:4000/api/users - Failed to load resource'
+          )
+      )
+    ).toBe(false);
 
     await checkinSandbox(sandboxId);
     await browser.executeScript('window.localStorage.clear();');

--- a/angular/src/app/api.ts
+++ b/angular/src/app/api.ts
@@ -25,7 +25,6 @@ const getSandboxCookie = () => {
 const client = () => {
   const token = window.localStorage.getItem('token');
   const sandbox = getSandboxCookie();
-  console.log(sandbox, 'sandbox');
   const headers = {
     ...(token && { Authorization: `Bearer ${token}` }),
     ...(sandbox && { sandbox }),

--- a/angular/src/app/app.component.html
+++ b/angular/src/app/app.component.html
@@ -11,5 +11,6 @@
 <!-- Toolbar -->
 <main>
   <app-navigation></app-navigation>
+  <app-error></app-error>
   <router-outlet></router-outlet>
 </main>

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { TodosComponent } from './todos/todos.component';
 import { TodoComponent } from './todos/todo/todo.component';
 import { NewTodoComponent } from './todos/new-todo/new-todo.component';
 import { NavigationComponent } from './navigation/navigation.component';
+import { ErrorComponent } from './error/error.component';
 
 @NgModule({
   declarations: [
@@ -20,6 +21,7 @@ import { NavigationComponent } from './navigation/navigation.component';
     RegisterComponent,
     TodoComponent,
     TodosComponent,
+    ErrorComponent,
   ],
   imports: [AppRoutingModule, BrowserModule, FormsModule],
 

--- a/angular/src/app/error/error.component.html
+++ b/angular/src/app/error/error.component.html
@@ -1,0 +1,1 @@
+<div class="error" *ngIf="error">{{error}}</div>

--- a/angular/src/app/error/error.component.spec.ts
+++ b/angular/src/app/error/error.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorComponent } from './error.component';
+
+describe('ErrorComponent', () => {
+  let component: ErrorComponent;
+  let fixture: ComponentFixture<ErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ErrorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/src/app/error/error.component.ts
+++ b/angular/src/app/error/error.component.ts
@@ -9,7 +9,7 @@ import { state } from '../store';
 export class ErrorComponent implements OnInit {
   constructor() {}
 
-  get error() {
+  get error(): typeof state['error'] {
     return state.error;
   }
 

--- a/angular/src/app/error/error.component.ts
+++ b/angular/src/app/error/error.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { state } from '../store';
+
+@Component({
+  selector: 'app-error',
+  templateUrl: './error.component.html',
+  styleUrls: ['./error.component.scss'],
+})
+export class ErrorComponent implements OnInit {
+  constructor() {}
+
+  get error() {
+    return state.error;
+  }
+
+  ngOnInit(): void {}
+}

--- a/angular/src/app/login/login.component.ts
+++ b/angular/src/app/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { login } from '../store';
+import { login, state } from '../store';
 
 @Component({
   selector: 'app-login',
@@ -17,6 +17,8 @@ export class LoginComponent implements OnInit {
 
   async login(): Promise<void> {
     await login(this.name, this.password);
-    this.router.navigate(['/']);
+    if (state.authenticated) {
+      this.router.navigate(['/']);
+    }
   }
 }

--- a/angular/src/app/navigation/navigation.component.ts
+++ b/angular/src/app/navigation/navigation.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { state, logout } from '../store';
 
 @Component({
@@ -8,12 +8,13 @@ import { state, logout } from '../store';
   styleUrls: ['./navigation.component.scss'],
 })
 export class NavigationComponent implements OnInit {
-  constructor() {}
+  constructor(private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit(): void {}
 
-  logout(): void {
-    logout();
+  async logout(): Promise<void> {
+    await logout();
+    this.router.navigate(['/login']);
   }
 
   get authenticated(): boolean {

--- a/angular/src/app/register/register.component.ts
+++ b/angular/src/app/register/register.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { register } from '../store';
+import { register, state } from '../store';
 
 @Component({
   selector: 'app-register',
@@ -18,6 +18,8 @@ export class RegisterComponent implements OnInit {
 
   async register(): Promise<void> {
     await register(this.name, this.password);
-    this.router.navigate(['/']);
+    if (state.authenticated) {
+      this.router.navigate(['/']);
+    }
   }
 }

--- a/angular/src/app/store.ts
+++ b/angular/src/app/store.ts
@@ -14,10 +14,12 @@ export type User = {
 type State = {
   authenticated: boolean;
   todos: Todo[];
+  error: string | null;
 };
 
 export const state: State = {
   authenticated: !!localStorage.getItem('token'),
+  error: null,
   todos: [],
 };
 
@@ -27,17 +29,27 @@ export const logout = () => {
 };
 
 export const login = async (name: string, password: string) => {
-  const { data: token } = await post<string>('login', {
-    login: { name, password },
-  });
-  localStorage.setItem('token', token);
-  state.authenticated = true;
+  state.error = null;
+  try {
+    const { data: token } = await post<string>('login', {
+      login: { name, password },
+    });
+    localStorage.setItem('token', token);
+    state.authenticated = true;
+  } catch (e) {
+    state.error = 'Invalid credentials';
+  }
 };
 
 export const register = async (name: string, password: string) => {
-  const response = await post<User>('users', { user: { name, password } });
-  if ('data' in response) {
-    return login(name, password);
+  state.error = null;
+  try {
+    const response = await post<User>('users', { user: { name, password } });
+    if ('data' in response) {
+      return login(name, password);
+    }
+  } catch (e) {
+    state.error = 'Invalid credentials';
   }
 };
 


### PR DESCRIPTION
Add failure status to angular login/register

Closes #25

Fix several smaller bugs

- login always redirecting to / even on failure
- register always redirecting to / even on failure
- logout not redirecting to /login

# What this PR does

Put the PR description here

# Check List

## Angular

- [x] New public interfaces are documented

## React

- [x] New public interfaces are documented

## Vue

- [x] New public interfaces are documented

## Backend

- [x] All new modules have @moduledoc
- [x] All new public functions have @doc
- [x] There are no compiler warnings
